### PR TITLE
修正文字超出控件宽度时显示不全，以省略号代替

### DIFF
--- a/Library/src/main/java/com/jp/wheelview/WheelView.java
+++ b/Library/src/main/java/com/jp/wheelview/WheelView.java
@@ -10,6 +10,8 @@ import android.graphics.Rect;
 import android.graphics.Shader.TileMode;
 import android.os.Handler;
 import android.os.Message;
+import android.text.TextPaint;
+import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.View;
@@ -190,7 +192,7 @@ public class WheelView extends View {
             return;
         try {
             for (ItemObject itemObject : itemList) {
-                itemObject.drawSelf(canvas);
+                itemObject.drawSelf(canvas, getMeasuredWidth());
             }
         } catch (Exception e) {
         }
@@ -666,7 +668,7 @@ public class WheelView extends View {
         /**
          * 字体画笔
          */
-        private Paint textPaint;
+        private TextPaint textPaint;
         /**
          * 字体范围矩形
          */
@@ -679,12 +681,13 @@ public class WheelView extends View {
         /**
          * 绘制自身
          *
-         * @param canvas
+         * @param canvas         画板
+         * @param containerWidth 容器宽度
          */
-        public void drawSelf(Canvas canvas) {
+        public void drawSelf(Canvas canvas, int containerWidth) {
 
             if (textPaint == null) {
-                textPaint = new Paint();
+                textPaint = new TextPaint();
                 textPaint.setAntiAlias(true);
             }
 
@@ -709,6 +712,8 @@ public class WheelView extends View {
             }
 
             // 返回包围整个字符串的最小的一个Rect区域
+            itemText = (String) TextUtils.ellipsize(itemText, textPaint, containerWidth,
+                    TextUtils.TruncateAt.END);
             textPaint.getTextBounds(itemText, 0, itemText.length(), textRect);
             // 判断是否可视
             if (!isInView())


### PR DESCRIPTION
有时候WheelView中的文字较长，会超出控件本身宽度，这时会导致文字显示不正常；例如中国行政区划级联效果，可能会有“海西蒙古族藏族自治州”、“克孜勒苏柯尔克孜自治州”等行政单位，这时控件的显示效果较差。
pull request中的代码使用TextUtils类将过长的字符串截断并加了"..."后缀，显示效果较好一些！

``` java
TextUtils.ellipsize(itemText, textPaint, containerWidth, TextUtils.TruncateAt.END);
```

大体效果如下图所示：

![image](https://cloud.githubusercontent.com/assets/4401837/10459668/2b740d1a-7203-11e5-941b-0d819a8aa48c.png)
