### PR TITLE
fix bug:android 7.0 getWidth  return 0

### DIFF
--- a/Library/src/main/java/com/jp/wheelview/WheelView.java
+++ b/Library/src/main/java/com/jp/wheelview/WheelView.java
@@ -192,9 +192,9 @@ public class WheelView extends View {
     @Override
     protected void onMeasure(int widthMeasureSpec, int heightMeasureSpec) {
         super.onMeasure(widthMeasureSpec, heightMeasureSpec);
-        controlWidth = getWidth();
+        controlWidth = getMeasuredWidth();
         if (controlWidth != 0) {
-            setMeasuredDimension(getWidth(), itemNumber * unitHeight);
+            setMeasuredDimension(getMeasuredWidth(), itemNumber * unitHeight);
         }
     }
 


### PR DESCRIPTION
fix bug:android 7.0 getWidth  return 0,I use getMeasuredWidth() replace getWidth,It's Ok.